### PR TITLE
Correct Name Conventions + Change Function Name

### DIFF
--- a/app/jobs/generate_daily_result_stats_job.rb
+++ b/app/jobs/generate_daily_result_stats_job.rb
@@ -7,7 +7,7 @@ class GenerateDailyResultStatsJob < ApplicationJob
   def perform(*_args)
     GenerateResultStat::DailyStat.call
     current_date = Date.current
-    return unless current_date == third_monday(current_date)
+    return unless current_date == monday_of_third_wednesday_week(current_date)
 
     GenerateResultStat::MonthlyStat.call(date)
   end

--- a/app/services/generate_result_stat/monthly_stat.rb
+++ b/app/services/generate_result_stat/monthly_stat.rb
@@ -17,7 +17,7 @@ module GenerateResultStat
         # In SQL Invocation, The data is fetched directly using PostgreSQL query.
         # One of them could be used as per preference!
         current_month_wednesday = Date.parse(date)
-        previous_month_wednesday = third_monday(current_month_wednesday - 1.months)
+        previous_month_wednesday = monday_of_third_wednesday_week(current_month_wednesday - 1.months)
         if INVOCATION.downcase == 'ruby'
           GenerateResultStat::MonthlyResultStat::RubyInvocation.new(previous_month_wednesday, current_month_wednesday).call
         else

--- a/lib/utilities.rb
+++ b/lib/utilities.rb
@@ -2,10 +2,10 @@
 
 # This is utility class to hold utility methods so that DRY could be followed
 module Utilities
-  def third_monday(date)
+  def monday_of_third_wednesday_week(date)
     # This function returns the Monday of the week on which the third wednesday of the month of which the date parameter is passed.
-    monthly_mondays = (date.beginning_of_month..date.end_of_month).select(&:wednesday?)
-    monthly_mondays[2].beginning_of_week
+    monthly_wednesdays = (date.beginning_of_month..date.end_of_month).select(&:wednesday?)
+    monthly_wednesdays[2].beginning_of_week
   end
 
   def get_collection_result_count(collection)


### PR DESCRIPTION
1. Changed utility method name to reflect output much effectively
2. Changed variable names for sake of improving code readability